### PR TITLE
Removed deprecated domain (now pinpayments.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Java Wrapper for PinPayments API
 
-This is a Java wrapper around `pin.net.au` API, which follows the structure of PinPayments' original RESTful API and covers all RESTful services completely.
+This is a Java wrapper around `pinpayments.com` API, which follows the structure of PinPayments' original RESTful API and covers all RESTful services completely.
 
 All wrapper methods have been covered with integration tests against PinPayments' test environment.
 

--- a/doc/API/01 Charges.md
+++ b/doc/API/01 Charges.md
@@ -10,7 +10,7 @@ private ChargesApi chargesApi;
 
 public final void myBusinessMethod() {
   final ChargeResponse chargeResponse = chargesApi.create(ImmutableCharge.builder()
-    .email("roland@pin.net.au")
+    .email("roland@pinpayments.com")
     .currency("AUD")
     .description("test charge")
     .amount(400)

--- a/doc/API/02 Customers.md
+++ b/doc/API/02 Customers.md
@@ -12,7 +12,7 @@ private CustomersApi customersApi;
 
 public final void myBusinessMethod() {
   final CustomerResponse customerResponse = customersApi.create(ImmutableCustomer.builder()
-    .email("roland@pin.net.au")
+    .email("roland@pinpayments.com")
     .card(ImmutableCard.builder()
       .number("5520000000000000")
       .expiryMonth("05")
@@ -66,7 +66,7 @@ public final void myBusinessMethod() {
   final String customerToken = "customer-token";
   final CustomerResponse updated = customersApi
       .update(customerToken, ImmutableCustomer.builder()
-         .email("roland@pin.net.au")
+         .email("roland@pinpayments.com")
          .card(ImmutableCard.builder()
            .number("5520000000000000")
            .expiryMonth("05")

--- a/doc/API/05 Recipients.md
+++ b/doc/API/05 Recipients.md
@@ -10,7 +10,7 @@ private RecipientsApi recipientsApi;
 
 public final void myBusinessMethod() {
   final RecipientResponse response = recipientsApi.create(ImmutableRecipient.builder()
-    .email("roland@pin.net.au")
+    .email("roland@pinpayments.com")
     .name("Mr Roland Robot")
     .bankAccount(buildBankAccount()).build());
   assertThat(response.response().token()).isNotBlank();

--- a/doc/need help.md
+++ b/doc/need help.md
@@ -1,6 +1,6 @@
 # Need help?
 
-The official documentation of the original HTTP RESTful API from PinPayments can be found from this link: [https://pin.net.au/docs/api/charges](https://pin.net.au/docs/api/charges).
+The official documentation of the original HTTP RESTful API from PinPayments can be found from this link: [https://pinpayments.com/docs/api/charges](https://pinpayments.com/docs/api/charges).
 
 ## Have a question?
 

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-This is a Java wrapper around pin.net.au API, which follows the structure of PinPayments' original RESTful API and covers all RESTful services completely.
+This is a Java wrapper around pinpayments.com API, which follows the structure of PinPayments' original RESTful API and covers all RESTful services completely.
 
 All wrapper methods have been covered with integration tests against PinPayments' test environment.
 
@@ -84,7 +84,7 @@ private ChargesApi chargesApi;
 
 public final void myBusinessMethod() {
   final ChargeResponse chargeResponse = chargesApi.create(ImmutableCharge.builder()
-    .email("roland@pin.net.au")
+    .email("roland@pinpayments.com")
     .currency("AUD")
     .description("test charge")
     .amount(400)

--- a/src/main/java/io/practiceinsight/pinpayments/PinPaymentsModule.java
+++ b/src/main/java/io/practiceinsight/pinpayments/PinPaymentsModule.java
@@ -29,8 +29,8 @@ import io.practiceinsight.pinpayments.annotation.PinVersion;
  */
 public class PinPaymentsModule extends AbstractModule {
 
-  private static final String PIN_BASEURL_TEST = "https://test-api.pin.net.au";
-  private static final String PIN_BASEURL_PROD = "https://api.pin.net.au";
+  private static final String PIN_BASEURL_TEST = "https://test-api.pinpayments.com";
+  private static final String PIN_BASEURL_PROD = "https://api.pinpayments.com";
   private static final String PIN_VERSION = "1";
 
   private final Env env;

--- a/src/main/java/io/practiceinsight/pinpayments/TestCard.java
+++ b/src/main/java/io/practiceinsight/pinpayments/TestCard.java
@@ -18,7 +18,7 @@ package io.practiceinsight.pinpayments;
 
 /**
  * Test cards provided by PinPayments. For more information please see:
- * <a href="https://pin.net.au/docs/api/test-cards">https://pin.net.au/docs/api/test-cards</a>
+ * <a href="https://pinpayments.com/docs/api/test-cards">https://pinpayments.com/docs/api/test-cards</a>
  *
  * @author delight.wjk@gmail.com
  */

--- a/src/main/java/io/practiceinsight/pinpayments/api/BalanceApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/BalanceApi.java
@@ -24,9 +24,9 @@ import io.practiceinsight.pinpayments.api.impl.BalanceApiImpl;
 /**
  * The balance API allows you to see the current balance of funds in your Pin Payments
  * account. You can use this to confirm whether a
- * <a href="https://pin.net.au/docs/api/transfers">transfer</a> is possible.
+ * <a href="https://pinpayments.com/docs/api/transfers">transfer</a> is possible.
  *
- * @see <a href="https://pin.net.au/docs/api/balance">Balance API</a>
+ * @see <a href="https://pinpayments.com/docs/api/balance">Balance API</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(BalanceApiImpl.class)

--- a/src/main/java/io/practiceinsight/pinpayments/api/BankAccountsApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/BankAccountsApi.java
@@ -25,12 +25,12 @@ import io.practiceinsight.pinpayments.api.impl.BankAccountsApiImpl;
 /**
  * The bank account API allows you to securely store bank account details in exchange
  * for a bank account token. This token can then be used to create a recipient using the
- * <a href="https://pin.net.au/docs/api/recipients">recipients API</a>.
+ * <a href="https://pinpayments.com/docs/api/recipients">recipients API</a>.
  *
  * <p>A bank account token can only be used once to create a recipient. The token automatically
  * expires after 1 month if it hasn't been used.</p>
  *
- * @see <a href="https://pin.net.au/docs/api/bank-accounts">Bank Accounts API</a>
+ * @see <a href="https://pinpayments.com/docs/api/bank-accounts">Bank Accounts API</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(BankAccountsApiImpl.class)

--- a/src/main/java/io/practiceinsight/pinpayments/api/CardTokensApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/CardTokensApi.java
@@ -35,7 +35,7 @@ import io.practiceinsight.pinpayments.api.impl.CardTokensApiImpl;
  * <p>A card token can only be used once, to create either a charge or a customer. If
  * no charge or customer is created within 1 month, the token is automatically expired.
  *
- * @see <a href="https://pin.net.au/docs/api/cards">https://pin.net.au/docs/api/cards</a>
+ * @see <a href="https://pinpayments.com/docs/api/cards">https://pinpayments.com/docs/api/cards</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(CardTokensApiImpl.class)

--- a/src/main/java/io/practiceinsight/pinpayments/api/ChargesApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/ChargesApi.java
@@ -28,7 +28,7 @@ import io.practiceinsight.pinpayments.pojo.SearchCriteria;
  * The charges API allows you to create new credit card charges, and to retrieve details
  * of previous charges.
  *
- * @see <a href="https://pin.net.au/docs/api/charges">Charges API</a>
+ * @see <a href="https://pinpayments.com/docs/api/charges">Charges API</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(ChargesApiImpl.class)
@@ -36,7 +36,7 @@ public interface ChargesApi {
 
   /**
    * Creates a new charge and returns its details. This may be a
-   * <a href="https://pin.net.au/docs/api#long-running-requests">long-running request</a>.
+   * <a href="https://pinpayments.com/docs/api#long-running-requests">long-running request</a>.
    *
    * @param charge The charge specified.
    * @return The details of the new charge created.

--- a/src/main/java/io/practiceinsight/pinpayments/api/CustomersApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/CustomersApi.java
@@ -37,7 +37,7 @@ import io.practiceinsight.pinpayments.pojo.DeletionResult;
  * this primary card. It contains a member called primary, which says whether the card is
  * a customer’s primary card; its value will always be true.</p>
  *
- * @see <a href="https://pin.net.au/docs/api/customers">Customers API</a>
+ * @see <a href="https://pinpayments.com/docs/api/customers">Customers API</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(CustomersApiImpl.class)

--- a/src/main/java/io/practiceinsight/pinpayments/api/EventsApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/EventsApi.java
@@ -26,7 +26,7 @@ import io.practiceinsight.pinpayments.api.impl.EventsApiImpl;
  * The events API allows you to view the activity on your account. Note that some actions
  * may create multiple events.
  *
- * @see <a href="https://pin.net.au/docs/api/events">Events API</a>
+ * @see <a href="https://pinpayments.com/docs/api/events">Events API</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(EventsApiImpl.class)

--- a/src/main/java/io/practiceinsight/pinpayments/api/RecipientsApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/RecipientsApi.java
@@ -27,9 +27,9 @@ import io.practiceinsight.pinpayments.pojo.TransferListResponse;
 /**
  * The recipients API allows you to post bank account details and retrieve a token that
  * you can safely store in your app. You can send funds to recipients using
- * the <a href="https://pin.net.au/docs/api/transfers">transfers API</a>.
+ * the <a href="https://pinpayments.com/docs/api/transfers">transfers API</a>.
  *
- * @see <a href="https://pin.net.au/docs/api/recipients">Recipients API</a>
+ * @see <a href="https://pinpayments.com/docs/api/recipients">Recipients API</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(RecipientsApiImpl.class)

--- a/src/main/java/io/practiceinsight/pinpayments/api/RefundsApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/RefundsApi.java
@@ -26,7 +26,7 @@ import io.practiceinsight.pinpayments.pojo.RefundResponse;
 /**
  * The refunds API allows you to refund a charge, and retrieve the details of previous refunds.
  *
- * @see <a href="https://pin.net.au/docs/api/refunds">Refunds API</a>
+ * @see <a href="https://pinpayments.com/docs/api/refunds">Refunds API</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(RefundsApiImpl.class)

--- a/src/main/java/io/practiceinsight/pinpayments/api/TransfersApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/TransfersApi.java
@@ -29,7 +29,7 @@ import io.practiceinsight.pinpayments.pojo.TransferResponse;
  * The transfers API allows you to send money to Australian bank accounts, and to
  * retrieve details of previous transfers.
  *
- * @see <a href="https://pin.net.au/docs/api/transfers">Transfers API</a>
+ * @see <a href="https://pinpayments.com/docs/api/transfers">Transfers API</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(TransfersApiImpl.class)

--- a/src/main/java/io/practiceinsight/pinpayments/api/WebhookEndpointsApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/WebhookEndpointsApi.java
@@ -28,7 +28,7 @@ import io.practiceinsight.pinpayments.api.impl.WebhookEndpointsApiImpl;
  * The Webhook Endpoints API allows you to create and view your webhook endpoints to enable
  * your website to receive push notifications of events that occur on your Pin Payments account.
  *
- * @see <a href="https://pin.net.au/docs/api/webhook_endpoints">Webhook Endpoints API Beta</a>
+ * @see <a href="https://pinpayments.com/docs/api/webhook_endpoints">Webhook Endpoints API Beta</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(WebhookEndpointsApiImpl.class)

--- a/src/main/java/io/practiceinsight/pinpayments/api/WebhooksApi.java
+++ b/src/main/java/io/practiceinsight/pinpayments/api/WebhooksApi.java
@@ -32,7 +32,7 @@ import io.practiceinsight.pinpayments.pojo.WebhookResponse;
  * error information recorded for the original request and record any new errors that
  * occur during the replay.</p>
  *
- * @see <a href="https://pin.net.au/docs/api/webhooks">Webhooks API</a>
+ * @see <a href="https://pinpayments.com/docs/api/webhooks">Webhooks API</a>
  * @author delight.wjk@gmail.com
  */
 @ImplementedBy(WebhooksApiImpl.class)

--- a/src/test/java/io/practiceinsight/pinpayments/TestDataFactory.java
+++ b/src/test/java/io/practiceinsight/pinpayments/TestDataFactory.java
@@ -53,7 +53,7 @@ public class TestDataFactory {
   public final Charge buildCharge(final TestCard testCard, final boolean capture) {
     final int amount = 400;
     return ImmutableCharge.builder()
-        .email("roland@pin.net.au")
+        .email("roland@pinpayments.com")
         .currency("AUD")
         .description("test charge")
         .amount(amount)
@@ -86,7 +86,7 @@ public class TestDataFactory {
   }
 
   public final Customer buildCustomer() {
-    return ImmutableCustomer.builder().email("roland@pin.net.au")
+    return ImmutableCustomer.builder().email("roland@pinpayments.com")
         .card(buildCard(TestCard.SuccessMasterCard)).build();
   }
 
@@ -96,7 +96,7 @@ public class TestDataFactory {
 
   public final Recipient buildRecipient() {
     return ImmutableRecipient.builder()
-        .email("roland@pin.net.au")
+        .email("roland@pinpayments.com")
         .name("Mr Roland Robot")
         .bankAccount(buildBankAccount()).build();
   }


### PR DESCRIPTION
While pin.net.au continues to work, it has been deprecated. This PR updates the URLs to point to the international domain that Pin Payments is shifting to the fore.